### PR TITLE
Pin AWS SDK to version 1 so script works

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'aws-sdk'
+gem 'aws-sdk', '~> 1'
 gem 'terminal-table'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,11 +4,11 @@ GEM
     aws-sdk (1.41.0)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
-    json (1.8.1)
+    json (1.8.3)
     mini_portile (0.6.0)
     nokogiri (1.6.2.1)
       mini_portile (= 0.6.0)
-    terminal-table (1.4.5)
+    terminal-table (1.5.2)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
Too much has changed in v2 of the AWS SDK to make updating easy, so I took the other way out.

Also version bumped some gems that could be.